### PR TITLE
fix #1

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -140,6 +140,8 @@
 			// 不正な値のときは警告表示にする。
 			latlngFieldWarning = true;
 		} else {
+			// 正常な値のときは通常表示にする。
+			latlngFieldWarning = false;
 			map.setView(latlng);
 		}
 	}


### PR DESCRIPTION
緯度経度フィールドにおいて警告表示の赤文字になった後、正常な値を入力すると黒文字に戻るよう、フラグを修正。